### PR TITLE
add missing include header

### DIFF
--- a/native-app/utils.cpp
+++ b/native-app/utils.cpp
@@ -4,7 +4,7 @@
 #include "version.h"
 #include "main.h"
 #include "dialogs/tinyfiledialogs.h"
-
+#include <cstring>
 
 #if defined _PLATFORM_WIN
     #include <Windows.h>


### PR DESCRIPTION
`#include <cstring>` was missing, preventing compilation on Linux (and the other platforms too, I assume.) This fixes it.