### PR TITLE
Add missing <string.h> to fix compilation with gcc 12

### DIFF
--- a/native-app/utils.cpp
+++ b/native-app/utils.cpp
@@ -1,4 +1,5 @@
 ﻿#include <stdarg.h>
+#include <string.h>
 #include <iostream>
 #include "utils.h"
 #include "version.h"


### PR DESCRIPTION
This header (or <cstring>) must be included to use strlen() and strcmp() and not doing it resulted in errors when compiling with gcc 12 under Linux.

---

This fixes the following:

```console
$ g++ -o utils.o utils.cpp
utils.cpp: In function ‘void Log(const char*, ...)’:
utils.cpp:45:19: error: ‘strlen’ was not declared in this scope
   45 |     int n = ((int)strlen(format)) * 2; /* Reserve two times as much as the length of format */
      |                   ^~~~~~
utils.cpp:14:1: note: ‘strlen’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
   13 |     #include <libgen.h>
  +++ |+#include <cstring>
   14 | #endif
utils.cpp: In function ‘bool hasCmdlineParam(const char*)’:
utils.cpp:102:13: error: ‘strcmp’ was not declared in this scope
  102 |         if (strcmp(search, process_argv[i]) == 0) return true;
      |             ^~~~~~
utils.cpp:102:13: note: ‘strcmp’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
```